### PR TITLE
feat: support GNOME 50 session switching

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,18 +3,25 @@
 cd "$(dirname "$0")/src"
 # automatically generate name from metadata info
 extension=$(cat metadata.json | grep uuid | awk '{print $2}' | tr -d '",')
+if [ -z "$extension" ]; then
+	echo "Error: extension UUID is empty. Aborting."
+	exit 1
+else
+	echo "Extension UUID: $extension"
+fi
+
 LOCAL_DIR="$HOME/.local/share/gnome-shell/extensions/$extension"
 SYSTEM_DIR="/usr/share/gnome-shell/extensions/$extension"
 
-while getopts 's:-system:c:-compile:d:-debug:h:-help:' flag; do
-	case "${flag}" in
-		s | --system)
+while [ $# -gt 0 ] ; do
+	case "$1" in
+		-s | --system)
 			system_install=true;;
-		c | --compile)
+		-c | --compile)
 			compile_schema=true;;
-		d | --debug)
+		-d | --debug)
 			debug_mode=true;;
-		h | --help)
+		-h | --help)
 			echo "Usage"
 			echo -e "\t ./auto_install.sh [options]\n"
 			echo -e "META OPTIONS"
@@ -24,8 +31,12 @@ while getopts 's:-system:c:-compile:d:-debug:h:-help:' flag; do
 			echo -e "--system\t install system wide (run as root)"
 			echo -e "-c,--compile\t to recompile the extension schema (requires glib-compile-schemas)"
 			echo -e "-d,--debug\t debug mode"
-			exit 0;
+			exit 0;;
+		*)
+			echo "Unknown option: $1"
+			echo "Use -h or --help for usage information.";;
 	esac
+	shift
 done
 
 #option for system wide install
@@ -49,7 +60,7 @@ fi
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 
-printf "\e[32mCopying extension files to target directory:\n\e[0m"
+echo -e "\e[32mCopying extension files to target directory:\e[0m"
 cp -Rv ./* $INSTALL_DIR
 
 #go back to original folder

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,7 +7,6 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 import Gdm from 'gi://Gdm';
-import AccountsService from 'gi://AccountsService';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 let indicator = null;
@@ -41,9 +40,12 @@ class EasyUserSwitch extends PanelMenu.Button {
 		});
 		this.box.add_child(icon);
 
-		this.connect('button-press-event',(_a, event) => this._updateMenu()); //generate menu on click
+		this.menu.connect('open-state-changed', (_menu, open) => {
+			if (open)
+				this._updateMenu();
+		}); //generate menu on open
 
-		Main.panel.addToStatusArea('EasyUserSwitch',this,0,'right'); //position,panel_side
+		this._updateMenu(); //populate menu before first open
 	}
 
 	_updateMenu() {
@@ -78,36 +80,27 @@ class EasyUserSwitch extends PanelMenu.Button {
 		// identify current user
 		let activeUser = GLib.get_user_name().toString();
 
-		//get list of logged in users
-		const userManager = AccountsService.UserManager.get_default();
-		let usersList = userManager.list_users();
-		usersList = usersList.filter( element => element.get_user_name() !== activeUser && element.is_logged_in());
-		if (DEBUG_MODE)
-			usersList.forEach((element) => {log(Date().substring(16,24)+' easy-user-switch/src/extension.js - user logged in: '+element.get_user_name());});
-
 		//extract loginctl info
 		let loginctl = JSON.parse(this._runShell('loginctl list-sessions --json=short'));
-		loginctl = loginctl.filter( element => element.seat == "seat0"); //only keep graphical users (exclude pihole, ...)
-		let loginctlInfo = loginctl.filter( element => element.user !== activeUser && element.user !== 'gdm'); //list of connected users exlucing current user
+		loginctl = loginctl.filter( element => element.seat == "seat0" && element.class == "user" && element.tty); //only keep switchable graphical users
+		let loginctlInfo = [];
+		loginctl.forEach((element) => { //keep one switchable session per user
+			if (element.user !== activeUser && element.user !== 'gdm'){
+				loginctlInfo = loginctlInfo.filter((item) => item.user != element.user);
+				loginctlInfo.push(element);
+			}
+		});
 		if (DEBUG_MODE)
 			log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo: '+JSON.stringify(loginctlInfo));
 
 		//identify tty for each user
-		if(Object.keys(usersList).length > 0){
+		if(Object.keys(loginctlInfo).length > 0){
 			this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-			usersList.forEach((activeUser) => {
-				const username = activeUser.get_user_name();
+			loginctlInfo.forEach((item) => {
+				const username = item.user;
 				if (DEBUG_MODE)
 					log(Date().substring(16,24)+' easy-user-switch/src/extension.js - identifying tty for: '+username);
-
-				let item = [];
-				// item = loginctlInfo.findLast((element) => element.user == username); //doesnt' seem to work
-				loginctlInfo.forEach((element) => { //will pick the last match in case of user listed multiple times
-					if (element.user == username){
-						item = element;
-					}
-				});
 
 				if (DEBUG_MODE)
 					log(Date().substring(16,24)+' panel-user-switch/src/extension.js: '+item.user+' connected in '+item.tty+' ('+item.session+')');

--- a/src/extension.js
+++ b/src/extension.js
@@ -222,10 +222,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 	_showOSD(osdIcon,osdText){
 		const icon = Gio.Icon.new_for_string(osdIcon);
 		const monitor = global.display.get_current_monitor(); //identify current monitor for OSD
-		const defaultOsdTimeout = OsdWindow.HIDE_TIMEOUT;
-		OsdWindow.HIDE_TIMEOUT = Math.clamp(1500,40 * osdText.length,5000); //text length dependant OSD timeout duration to allow time to read
-		Main.osdWindowManager.show(monitor, icon, osdText); //display error
-		OsdWindow.HIDE_TIMEOUT = defaultOsdTimeout; //reset OSD timeout duration to default
+		Main.osdWindowManager.showOne(monitor, icon, osdText);
 	}
 });
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,8 +1,8 @@
-{"shell-version": [ "47", "48", "49" ],
+{"shell-version": [ "49", "50" ],
  "uuid": "easyuserswitch@batwam.corp",
  "name": "Easy User Switch",
  "url": "https://github.com/Batwam/easy_user_switch",
- "version": "2",
+ "version": "3",
  "description": "Switch between connected users from Gnome panel",
  "session-modes": ["user", "unlock-dialog"],
  "settings-schema": "org.gnome.shell.extensions.easy-user-switch"


### PR DESCRIPTION
GNOME 50 no longer made the old menu update path and AccountsService login state a reliable way to discover switchable sessions. That left the user switch menu empty or missing valid targets even while other graphical sessions were active.

Declare GNOME 50 support and list switch targets from live switchable logind sessions so the menu consistently exposes users that both loginctl and chvt can handle.