### PR TITLE
refactor: simplify session switching and drop legacy chvt support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,110 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: No rights reserved
+
+env:
+  es2021: true
+extends: 'eslint:recommended'
+rules:
+  array-callback-return: error
+  no-await-in-loop: error
+  no-constant-binary-expression: error
+  no-constructor-return: error
+  no-new-native-nonconstructor: error
+  no-promise-executor-return: error
+  no-self-compare: error
+  no-template-curly-in-string: error
+  no-unmodified-loop-condition: error
+  no-unreachable-loop: error
+  no-unused-private-class-members: error
+  no-use-before-define:
+    - error
+    - functions: false
+      classes: true
+      variables: true
+      allowNamedExports: true
+  block-scoped-var: error
+  complexity: warn
+  consistent-return: error
+  default-param-last: error
+  eqeqeq: error
+  no-array-constructor: error
+  no-caller: error
+  no-extend-native: error
+  no-extra-bind: error
+  no-extra-label: error
+  no-iterator: error
+  no-label-var: error
+  no-loop-func: error
+  no-multi-assign: warn
+  no-new-object: error
+  no-new-wrappers: error
+  no-proto: error
+  no-shadow: warn
+  no-unused-vars:
+    - error
+    - varsIgnorePattern: ^_
+      argsIgnorePattern: ^_
+  no-var: warn
+  unicode-bom: error
+  no-restricted-globals:
+    - error
+    - name: Debugger
+      message: Internal use only
+    - name: GIRepositoryGType
+      message: Internal use only
+    - name: log
+      message: Use console.log()
+    - name: logError
+      message: Use console.warn() or console.error()
+  no-restricted-properties:
+    - error
+    - object: imports
+      property: format
+      message: Use template strings
+    - object: pkg
+      property: initFormat
+      message: Use template strings
+    - object: Lang
+      property: copyProperties
+      message: Use Object.assign()
+    - object: Lang
+      property: bind
+      message: Use arrow notation or Function.prototype.bind()
+    - object: Lang
+      property: Class
+      message: Use ES6 classes
+  no-restricted-syntax:
+    - error
+    - selector: >-
+        MethodDefinition[key.name="_init"]
+        CallExpression[arguments.length<=1][callee.object.type="Super"][callee.property.name="_init"]
+      message: Use constructor() and super()
+globals:
+  ARGV: readonly
+  Debugger: readonly
+  GIRepositoryGType: readonly
+  globalThis: readonly
+  imports: readonly
+  Intl: readonly
+  log: readonly
+  logError: readonly
+  pkg: readonly
+  print: readonly
+  printerr: readonly
+  window: readonly
+  TextEncoder: readonly
+  TextDecoder: readonly
+  console: readonly
+  setTimeout: readonly
+  setInterval: readonly
+  clearTimeout: readonly
+  clearInterval: readonly
+  global: readonly
+  _: readonly
+  C_: readonly
+  N_: readonly
+  ngettext: readonly
+parserOptions:
+  ecmaVersion: 2022
+  sourceType: module

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # Gnome Panel User Switch
-Gnome-shell extension to easily switch between **connected** users using an icon on the panel which lists the users currently logged in. It is similar to using Ctrl+Alt+Fn but the extension will identify the appropriate Virtual terminal for each user and provides the ability to do it directly from the gnome panel.
+Gnome-shell extension to easily switch between **connected** users using an icon on the panel which lists the users currently logged in. It is similar to using Ctrl+Alt+Fn but the extension will identify and list the associated Virtual terminal for each user and provides the ability to do it directly from the gnome panel.
 
 Note that is a user is not logged in, its name will not appear. You can then use the "Login Screen" option to go to the login screen and log this user in.
 
-This is loosely inspired by https://github.com/HROMANO/fastuserswitch in terms of functionality but switches Virtual Terminals by activating the target session through `loginctl`.
+This is loosely inspired by the now discontinued https://github.com/HROMANO/fastuserswitch in terms of functionality but switches Virtual Terminals by activating the target session through `loginctl`.
 
 # Install
-1. To install the extension locally (ie ~/.local/share/gnome-shell/extensions/): `./auto_install.sh`
+1. To install the extension locally (ie ~/.local/share/gnome-shell/extensions/): `./install.sh`
 2. Restart gnome-shell, using <kbd>Alt</kbd>+<kbd>F2</kbd> then `r`+<kbd>Enter</kbd> with Xorg or logout/login with Wayland.
 3. Enable the extension through your extensions manager or by running `gnome-extensions enable easyuserswitch@batwam.corp`
 
 # Alternative Install
-run `./auto_install.sh --help` for a full list of installation options available.
-
-Alternative installation options include:
 - Enable an extension for all users (system-wide)
-run `sudo ./auto_install.sh --system`
-- Show debug messages for testing purposes (requires Debug Mode on in the Preferences)
-run `sudo ./auto_install.sh --debug`
+run `sudo ./install.sh --system`
+
+# Testing and Develipment
+- Open the logs directly for testing purposes (recommended to use Debug Mode on in the Preferences):
+run `./install.sh --debug` or run directly `journalctl --follow -o cat /usr/bin/gnome-shell GNOME_SHELL_EXTENSION_UUID="easyuserswitch@batwam.corp"`
+- To recompile the schemas (regenerates gscemas.compiled if the xml file is being modifiled)
+run `./install.sh --compile`
 
 # Uninstall Extension
 - Disable the extension
@@ -30,8 +31,9 @@ Delete the installed files either manually or by using the following commands:
 `sudo rm -rf /usr/share/gnome-shell/extensions/easyuserswitch@batwam.corp`
 
 Restart gnome-shell, using <kbd>Alt</kbd>+<kbd>F2</kbd> then `r`+<kbd>Enter</kbd> with Xorg or logout/login with Wayland.
+
 ## Extras
-Recommended system settings can be set in the Settings panel for the extension accessible through right click on the icon
-- An option is included to Enable/Disable the screen lock due to inactivity. This is a built-in gnome option which is only included in the Preferences for convenience
-- An option to lock the session when switching. If disabled, the user can easily switch between sessions, however, this also means that the second user can switch back to the first user's session as it will not be locked. Consider your own privacy objectives when activating this.
-- When Debug Mode is enabled in preferences, you can check the logs by running `journalctl --follow -o cat /usr/bin/gnome-shell GNOME_SHELL_EXTENSION_UUID="easyuserswitch@batwam.corp"`
+Recommended system settings can be set in the Settings panel for the extension accessible through right/left click on the icon or your extension manager. This includes:
+- An option is included to Enable/Disable the screen lock due to inactivity. This is a built-in gnome option which is only included in the Preferences for convenience.
+- An option to lock the session when switching. If disabled, the user can easily switch between sessions, however, this also means that the second user can switch back to the first user's session as it will not be locked. Consider your own privacy/security objectives when activating this.
+- An option to turn on DEBUG mode this will add debug information in the console (see above regarding `--debug` option)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ run `sudo ./install.sh --system`
 
 # Testing and Develipment
 - Open the logs directly for testing purposes (recommended to use Debug Mode on in the Preferences):
-run `./install.sh --debug` or run directly `journalctl --follow -o cat /usr/bin/gnome-shell GNOME_SHELL_EXTENSION_UUID="easyuserswitch@batwam.corp"`
+run `./install.sh --debug`.Alternatively, run directly `journalctl --follow -o cat /usr/bin/gnome-shell GNOME_SHELL_EXTENSION_UUID="easyuserswitch@batwam.corp"` or  `journalctl -f | grep easy-user-switch`
 - To recompile the schemas (regenerates gscemas.compiled if the xml file is being modifiled)
 run `./install.sh --compile`
 
@@ -34,6 +34,6 @@ Restart gnome-shell, using <kbd>Alt</kbd>+<kbd>F2</kbd> then `r`+<kbd>Enter</kbd
 
 ## Extras
 Recommended system settings can be set in the Settings panel for the extension accessible through right/left click on the icon or your extension manager. This includes:
-- An option is included to Enable/Disable the screen lock due to inactivity. This is a built-in gnome option which is only included in the Preferences for convenience.
-- An option to lock the session when switching. If disabled, the user can easily switch between sessions, however, this also means that the second user can switch back to the first user's session as it will not be locked. Consider your own privacy/security objectives when activating this.
+- An option is included to Enable/Disable the screen lock due to inactivity (Default = `true`). This is a built-in gnome option which is only included in the Preferences for convenience. Disabling it allows to be able to swith back and forth between session without requiring password (assuming automatic locking is disabled)
+- An option to lock the session when switching (Default = `false`). If enabled, the session will be locked before switching and requie password to switching back to the original session.
 - An option to turn on DEBUG mode this will add debug information in the console (see above regarding `--debug` option)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@ Gnome-shell extension to easily switch between **connected** users using an icon
 
 Note that is a user is not logged in, its name will not appear. You can then use the "Login Screen" option to go to the login screen and log this user in.
 
-This is loosely inspired by https://github.com/HROMANO/fastuserswitch in terms of functionality but uses an alternative method by simulating Ctrl+Alt+Fx to switch Virtual Terminal by running the `loginctl` command (or `chvt` as optional alternative).
-
-Alternatively, it can run the `chvt` command but this requires the `chvt` command to be added to the sudoers file (See preferenced to change method). This can be achieved by creating a file in your `etc/sudoers.d` folder and include the list of users who require using `chvt` as follows:
-`user1,user2,user3  ALL=(ALL:ALL) NOPASSWD: /usr/bin/chvt`
+This is loosely inspired by https://github.com/HROMANO/fastuserswitch in terms of functionality but switches Virtual Terminals by activating the target session through `loginctl`.
 
 # Install
 1. To install the extension locally (ie ~/.local/share/gnome-shell/extensions/): `./auto_install.sh`

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ INSTALL_DIR="$LOCAL_DIR"
 if [ "$system_install" == true ]; then
 	if [ "$EUID" -ne 0 ]; then
 		echo "Please run as root to install system wide."
-		echo "sudo $0 --system"
+		echo "sudo ./$0 --system"
 		exit
 	fi
 	echo "installing the extension system wide..."

--- a/src/extension.js
+++ b/src/extension.js
@@ -136,12 +136,12 @@ class EasyUserSwitch extends PanelMenu.Button {
 		const DEBUG_MODE = this.settings.get_boolean('debug-mode');
 
 		try {
-			let proc = Gio.Subprocess.new(
+			let subprocess = Gio.Subprocess.new(
 				argument,
 				Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
 			);
 
-			proc.communicate_utf8_async(null, null, (proc, res) => {
+			subprocess.communicate_utf8_async(null, null, (proc, res) => {
 				try {
 					let [, stdout, stderr] = proc.communicate_utf8_finish(res);
 					if (proc.get_successful()) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -51,7 +51,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 		const DEBUG_MODE = this.settings.get_boolean('debug-mode');
 
 		if (DEBUG_MODE)
-			log(Date().substring(16,24)+' easy-user-switch/src/extension.js: '+'_updateMenu()');
+			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js: '+'_updateMenu()');
 
 		this.menu.removeAll();
 
@@ -61,7 +61,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 		let sessionStatus = this._runShell('loginctl session-status');
 		this._activeSession = sessionStatus.substring(0,sessionStatus.indexOf(' '));//keep number before fors space
 		if (DEBUG_MODE)
-			log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo - Active session: '+JSON.stringify(this._activeSession));
+			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo - Active session: '+JSON.stringify(this._activeSession));
 
 		this._switch_user_item = new PopupMenu.PopupMenuItem(_("Login Screen"));
 		this._switch_user_item.connect('activate', () => {
@@ -90,7 +90,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 			}
 		});
 		if (DEBUG_MODE)
-			log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo: '+JSON.stringify(loginctlInfo));
+			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo: '+JSON.stringify(loginctlInfo));
 
 		//identify tty for each user
 		if(Object.keys(loginctlInfo).length > 0){
@@ -99,10 +99,10 @@ class EasyUserSwitch extends PanelMenu.Button {
 			loginctlInfo.forEach((item) => {
 				const username = item.user;
 				if (DEBUG_MODE)
-					log(Date().substring(16,24)+' easy-user-switch/src/extension.js - identifying tty for: '+username);
+					console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - identifying tty for: '+username);
 
 				if (DEBUG_MODE)
-					log(Date().substring(16,24)+' panel-user-switch/src/extension.js: '+item.user+' connected in '+item.tty+' ('+item.session+')');
+					console.log(Date().substring(16,24)+' panel-user-switch/src/extension.js: '+item.user+' connected in '+item.tty+' ('+item.session+')');
 
 				let displayName = item.user;
 				if (DEBUG_MODE) //provide tty info in menu
@@ -151,7 +151,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 					}
 				} catch (err) {
 					if (DEBUG_MODE)
-						log(Date().substring(16,24)+' easy-user-switch/src/extension.js - _runShell() communicate error: '+err);
+						console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - _runShell() communicate error: '+err);
 
 				} finally {
 					loop.quit();
@@ -159,7 +159,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 			});
 		} catch (err) {
 			if (DEBUG_MODE)
-				log(Date().substring(16,24)+' easy-user-switch/src/extension.js - _runShell() general error: '+err);
+				console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - _runShell() general error: '+err);
 		}
 		loop.run();
 		return output;
@@ -178,7 +178,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 	_lockActiveScreen(){
 		const DEBUG_MODE = this.settings.get_boolean ('debug-mode');
 		if (DEBUG_MODE)
-			log(Date().substring(16,24)+' easy-user-switch/src/extension.js: locking screen');
+			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js: locking screen');
 
 		Main.overview.hide(); //leave overview mode first if activated
 		Main.screenShield.lock(true); //lock screen
@@ -187,7 +187,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 	_switchTTY(item){
 		const DEBUG_MODE = this.settings.get_boolean ('debug-mode');
 		if (DEBUG_MODE)
-			log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctl to '+item.user+' (session '+item.session+')');
+			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctl to '+item.user+' (session '+item.session+')');
 
 		this._runShell('loginctl activate '+item.session); //switch to associated tty
 	}

--- a/src/extension.js
+++ b/src/extension.js
@@ -22,7 +22,7 @@ export default class EasyUserSwitchExtension extends Extension {
 	}
 }
 
-var EasyUserSwitch = GObject.registerClass(
+const EasyUserSwitch = GObject.registerClass(
 	{ GTypeName: 'EasyUserSwitch' },
 class EasyUserSwitch extends PanelMenu.Button {
 	_init(settings, extension){

--- a/src/extension.js
+++ b/src/extension.js
@@ -8,6 +8,8 @@ import St from 'gi://St';
 import Gdm from 'gi://Gdm';
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
+Gio._promisify(Gio.Subprocess.prototype, 'communicate_utf8_async');
+
 let indicator = null;
 const EasyUserSwitch = GObject.registerClass(
 	{ GTypeName: 'EasyUserSwitch' },
@@ -28,13 +30,13 @@ class EasyUserSwitch extends PanelMenu.Button {
 
 		this.menu.connect('open-state-changed', (_menu, open) => {
 			if (open)
-				this._updateMenu();
+				this._updateMenu().catch(err => this._logCommandError('Failed to update menu', err));
 		}); //generate menu on open
 
-		this._updateMenu(); //populate menu before first open
+		this._updateMenu().catch(err => this._logCommandError('Failed to initialize menu', err)); //populate menu before first open
 	}
 
-	_updateMenu() {
+	async _updateMenu() {
 		const DEBUG_MODE = this.settings.get_boolean('debug-mode');
 
 		if (DEBUG_MODE)
@@ -45,7 +47,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 		this.menu.addAction(_('Settings'), () => this._extension.openPreferences());
 		this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-		let sessionStatus = this._runShell('loginctl session-status');
+		let sessionStatus = await this._runCommand(['loginctl', 'session-status']);
 		this._activeSession = sessionStatus.substring(0,sessionStatus.indexOf(' '));//keep number before fors space
 		if (DEBUG_MODE)
 			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo - Active session: '+JSON.stringify(this._activeSession));
@@ -67,7 +69,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 		let activeUser = GLib.get_user_name().toString();
 
 		//extract loginctl info
-		let loginctl = JSON.parse(this._runShell('loginctl list-sessions --json=short'));
+		let loginctl = JSON.parse(await this._runCommand(['loginctl', 'list-sessions', '--json=short']));
 		loginctl = loginctl.filter( element => element.seat === "seat0" && element.class === "user" && element.tty); //only keep switchable graphical users
 		let loginctlInfo = [];
 		loginctl.forEach((element) => { //keep one switchable session per user
@@ -102,54 +104,47 @@ class EasyUserSwitch extends PanelMenu.Button {
 					if (this.settings.get_boolean ('lock-screen-on-switch')){
 						this._lockActiveScreen();
 						setTimeout(() => { //allow 500ms to lock before switching
-							this._switchTTY(item);
+							this._switchTTY(item).catch(err => this._logCommandError('Failed to activate session', err));
 						}, 500);
 					}
 					else
-						this._switchTTY(item);
+						this._switchTTY(item).catch(err => this._logCommandError('Failed to activate session', err));
 				});
 				this.menu.addMenuItem(menu_item);
 			});
 		}
 	}
 
-	_runShell(command){
-		//run shell command
-		//https://gjs.guide/guides/gio/subprocesses.html#communicating-with-processes
-		let loop = GLib.MainLoop.new(null, false);
-		let argument = GLib.shell_parse_argv(command)[1];
-		let output = false;
+	async _runCommand(argv, cancellable = null){
+		let cancelId = 0;
+		const flags = Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE;
+		const subprocess = new Gio.Subprocess({argv, flags});
 
-		const DEBUG_MODE = this.settings.get_boolean('debug-mode');
+		subprocess.init(cancellable);
+
+		if (cancellable instanceof Gio.Cancellable)
+			cancelId = cancellable.connect(() => subprocess.force_exit());
 
 		try {
-			let subprocess = Gio.Subprocess.new(
-				argument,
-				Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
-			);
+			const [stdout, stderr] = await subprocess.communicate_utf8_async(null, null);
+			const status = subprocess.get_exit_status();
 
-			subprocess.communicate_utf8_async(null, null, (proc, res) => {
-				try {
-					let [, stdout, stderr] = proc.communicate_utf8_finish(res);
-					if (proc.get_successful()) {
-						output = stdout;
-					} else {
-						throw new Error(stderr);
-					}
-				} catch (err) {
-					if (DEBUG_MODE)
-						console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - _runShell() communicate error: '+err);
+			if (status !== 0) {
+				throw new Gio.IOErrorEnum({
+					code: Gio.IOErrorEnum.FAILED,
+					message: stderr ? stderr.trim() : `Command '${argv}' failed with exit code ${status}`,
+				});
+			}
 
-				} finally {
-					loop.quit();
-				}
-			});
-		} catch (err) {
-			if (DEBUG_MODE)
-				console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - _runShell() general error: '+err);
+			return stdout.trim();
+		} finally {
+			if (cancelId > 0)
+				cancellable.disconnect(cancelId);
 		}
-		loop.run();
-		return output;
+	}
+
+	_logCommandError(context, err){
+		console.error(`easy-user-switch: ${context}`, err);
 	}
 
 	_disable(){
@@ -171,12 +166,12 @@ class EasyUserSwitch extends PanelMenu.Button {
 		Main.screenShield.lock(true); //lock screen
 	}
 
-	_switchTTY(item){
+	async _switchTTY(item){
 		const DEBUG_MODE = this.settings.get_boolean ('debug-mode');
 		if (DEBUG_MODE)
 			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctl to '+item.user+' (session '+item.session+')');
 
-		this._runShell('loginctl activate '+item.session); //switch to associated tty
+		await this._runCommand(['loginctl', 'activate', item.session]); //switch to associated tty
 	}
 });
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -6,7 +6,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 import Gdm from 'gi://Gdm';
-import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 let indicator = null;
 const EasyUserSwitch = GObject.registerClass(

--- a/src/extension.js
+++ b/src/extension.js
@@ -37,10 +37,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 	}
 
 	async _updateMenu() {
-		const DEBUG_MODE = this.settings.get_boolean('debug-mode');
-
-		if (DEBUG_MODE)
-			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js: '+'_updateMenu()');
+		this._logCommandDebug('_updateMenu()');
 
 		this.menu.removeAll();
 
@@ -49,8 +46,7 @@ class EasyUserSwitch extends PanelMenu.Button {
 
 		let sessionStatus = await this._runCommand(['loginctl', 'session-status']);
 		this._activeSession = sessionStatus.substring(0,sessionStatus.indexOf(' '));//keep number before fors space
-		if (DEBUG_MODE)
-			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo - Active session: '+JSON.stringify(this._activeSession));
+		this._logCommandDebug('loginctlInfo - Active session: ' + JSON.stringify(this._activeSession));
 
 		this._switch_user_item = new PopupMenu.PopupMenuItem(_("Login Screen"));
 		this._switch_user_item.connect('activate', () => {
@@ -78,8 +74,8 @@ class EasyUserSwitch extends PanelMenu.Button {
 				loginctlInfo.push(element);
 			}
 		});
-		if (DEBUG_MODE)
-			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctlInfo: '+JSON.stringify(loginctlInfo));
+		
+		this._logCommandDebug('loginctlInfo: '+JSON.stringify(loginctlInfo));
 
 		//identify tty for each user
 		if(Object.keys(loginctlInfo).length > 0){
@@ -87,15 +83,11 @@ class EasyUserSwitch extends PanelMenu.Button {
 
 			loginctlInfo.forEach((item) => {
 				const username = item.user;
-				if (DEBUG_MODE)
-					console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - identifying tty for: '+username);
-
-				if (DEBUG_MODE)
-					console.log(Date().substring(16,24)+' panel-user-switch/src/extension.js: '+item.user+' connected in '+item.tty+' ('+item.session+')');
+				this._logCommandDebug('identifying tty for: '+username);
+				this._logCommandDebug(item.user+' connected in '+item.tty+' ('+item.session+')');
 
 				let displayName = item.user;
-				if (DEBUG_MODE) //provide tty info in menu
-					displayName =  displayName +' ('+item.tty+', session '+item.session+')';
+				displayName =  displayName +' ('+item.tty+', session '+item.session+')';
 
 				let menu_item = new PopupMenu.PopupMenuItem(displayName);
 
@@ -147,6 +139,11 @@ class EasyUserSwitch extends PanelMenu.Button {
 		console.error(`easy-user-switch: ${context}`, err);
 	}
 
+	_logCommandDebug(context) {
+		if (this.settings.get_boolean('debug-mode'))
+			console.log(`easy-user-switch: ${context}`);
+	}
+
 	_disable(){
 		if(this.icon)
 			this.box.remove_child(this.icon);
@@ -158,18 +155,14 @@ class EasyUserSwitch extends PanelMenu.Button {
 	}
 
 	_lockActiveScreen(){
-		const DEBUG_MODE = this.settings.get_boolean ('debug-mode');
-		if (DEBUG_MODE)
-			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js: locking screen');
+		this._logCommandDebug('locking screen');
 
 		Main.overview.hide(); //leave overview mode first if activated
 		Main.screenShield.lock(true); //lock screen
 	}
 
 	async _switchTTY(item){
-		const DEBUG_MODE = this.settings.get_boolean ('debug-mode');
-		if (DEBUG_MODE)
-			console.log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctl to '+item.user+' (session '+item.session+')');
+		this._logCommandDebug('loginctl to '+item.user+' (session '+item.session+')');
 
 		await this._runCommand(['loginctl', 'activate', item.session]); //switch to associated tty
 	}

--- a/src/extension.js
+++ b/src/extension.js
@@ -9,19 +9,6 @@ import Gdm from 'gi://Gdm';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 let indicator = null;
-export default class EasyUserSwitchExtension extends Extension {
-	enable(){
-		indicator = new EasyUserSwitch(this.getSettings(), this);
-		Main.panel.addToStatusArea('easyuserswitch-menu', indicator);//added it so it shows in gdm too
-	}
-
-	disable(){
-		indicator._disable();
-		indicator.destroy();
-		indicator = null;
-	}
-}
-
 const EasyUserSwitch = GObject.registerClass(
 	{ GTypeName: 'EasyUserSwitch' },
 class EasyUserSwitch extends PanelMenu.Button {
@@ -192,3 +179,16 @@ class EasyUserSwitch extends PanelMenu.Button {
 		this._runShell('loginctl activate '+item.session); //switch to associated tty
 	}
 });
+
+export default class EasyUserSwitchExtension extends Extension {
+	enable(){
+		indicator = new EasyUserSwitch(this.getSettings(), this);
+		Main.panel.addToStatusArea('easyuserswitch-menu', indicator);//added it so it shows in gdm too
+	}
+
+	disable(){
+		indicator._disable();
+		indicator.destroy();
+		indicator = null;
+	}
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -81,11 +81,11 @@ class EasyUserSwitch extends PanelMenu.Button {
 
 		//extract loginctl info
 		let loginctl = JSON.parse(this._runShell('loginctl list-sessions --json=short'));
-		loginctl = loginctl.filter( element => element.seat == "seat0" && element.class == "user" && element.tty); //only keep switchable graphical users
+		loginctl = loginctl.filter( element => element.seat === "seat0" && element.class === "user" && element.tty); //only keep switchable graphical users
 		let loginctlInfo = [];
 		loginctl.forEach((element) => { //keep one switchable session per user
 			if (element.user !== activeUser && element.user !== 'gdm'){
-				loginctlInfo = loginctlInfo.filter((item) => item.user != element.user);
+				loginctlInfo = loginctlInfo.filter((item) => item.user !== element.user);
 				loginctlInfo.push(element);
 			}
 		});

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,7 +1,6 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
-import * as OsdWindow from 'resource:///org/gnome/shell/ui/osdWindow.js';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
@@ -187,42 +186,9 @@ class EasyUserSwitch extends PanelMenu.Button {
 
 	_switchTTY(item){
 		const DEBUG_MODE = this.settings.get_boolean ('debug-mode');
-		const ttyNumber = item.tty.replace("tty","");//only keep number
-
-		const SWITCH_METHOD = this.settings.get_string ('switch-method');
 		if (DEBUG_MODE)
-			log(Date().substring(16,24)+' easy-user-switch/src/extension.js - SWITCH_METHOD: '+SWITCH_METHOD);
+			log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctl to '+item.user+' (session '+item.session+')');
 
-		switch(SWITCH_METHOD){
-			case 'chvt':
-				if (DEBUG_MODE)
-					log(Date().substring(16,24)+' easy-user-switch/src/extension.js - chvt: '+item.tty);
-
-				let output = this._runShell('sudo chvt '+ttyNumber); //switch to associated tty
-
-				if (!output){
-					if (DEBUG_MODE)
-						log(Date().substring(16,24)+' easy-user-switch/src/extension.js: '+'no output, display OSD warning');
-
-					const activeUser = GLib.get_user_name().toString();
-					const osdText = 'Please add the following to the /etc/sudoers file:\n'+activeUser+' ALL=(ALL:ALL) NOPASSWD: /usr/bin/chvt*';
-					this._showOSD('error-symbolic',osdText);
-				}
-				break;
-
-			case 'loginctl':
-					if (DEBUG_MODE)
-						log(Date().substring(16,24)+' easy-user-switch/src/extension.js - loginctl to '+item.user+' (session '+item.session+')');
-
-					this._runShell('loginctl activate '+item.session); //switch to associated tty
-					break;
-		}
-	}
-
-	_showOSD(osdIcon,osdText){
-		const icon = Gio.Icon.new_for_string(osdIcon);
-		const monitor = global.display.get_current_monitor(); //identify current monitor for OSD
-		Main.osdWindowManager.showOne(monitor, icon, osdText);
+		this._runShell('loginctl activate '+item.session); //switch to associated tty
 	}
 });
-

--- a/src/extension.js
+++ b/src/extension.js
@@ -182,6 +182,11 @@ export default class EasyUserSwitchExtension extends Extension {
 	}
 
 	disable(){
+		// Session-mode changes tear down the visible indicator here, but
+		// lock-before-switch intentionally leaves a delayed handoff in flight.
+		// That flow locks the current session first, then completes the switch to
+		// GDM or another user from a 500ms timeout, so the extension still needs to
+		// run in unlock-dialog even though its panel UI is removed during disable().
 		indicator._disable();
 		indicator.destroy();
 		indicator = null;

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,6 @@
  "uuid": "easyuserswitch@batwam.corp",
  "name": "Easy User Switch",
  "url": "https://github.com/Batwam/easy_user_switch",
- "version": "3",
  "gettext-domain": "easyuserswitch@batwam.corp",
  "description": "Switch between connected users from Gnome panel",
  "session-modes": ["user", "unlock-dialog"],

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,6 +3,7 @@
  "name": "Easy User Switch",
  "url": "https://github.com/Batwam/easy_user_switch",
  "version": "3",
+ "gettext-domain": "easyuserswitch@batwam.corp",
  "description": "Switch between connected users from Gnome panel",
  "session-modes": ["user", "unlock-dialog"],
  "settings-schema": "org.gnome.shell.extensions.easy-user-switch"

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,7 +1,7 @@
 import Adw from 'gi://Adw';
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
-import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class EasyUserSwitchPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window){
@@ -14,24 +14,24 @@ export default class EasyUserSwitchPreferences extends ExtensionPreferences {
         page = new Adw.PreferencesPage();
 
         //System Preferences
-        group = new Adw.PreferencesGroup({ title: 'System Preferences'});
+        group = new Adw.PreferencesGroup({ title: _('System Preferences')});
         // group.set_description('Update relevant System Preferences');
         page.add(group);
-        this.addToggle('Automatic Screen Lock',"Disable to prevent session from locking due to inactivity",'lock-enabled',systemSettings,group);
+        this.addToggle(_('Automatic Screen Lock'),_('Disable to prevent session from locking due to inactivity'),'lock-enabled',systemSettings,group);
 
         //Extension Preferences
-        group = new Adw.PreferencesGroup({ title: 'Extension Preferences'});
+        group = new Adw.PreferencesGroup({ title: _('Extension Preferences')});
         // group.set_description('Update Extension Preferences');
         page.add(group);
-        this.addToggle('Lock session before switching',"Enable to require password when switching back",'lock-screen-on-switch',extensionSettings,group);
-        this.addToggle('Debug Mode','Enable to generate debug messages in `journalctl -f | grep easy-user-switch`','debug-mode',extensionSettings,group);
+        this.addToggle(_('Lock session before switching'),_('Enable to require password when switching back'),'lock-screen-on-switch',extensionSettings,group);
+        this.addToggle(_('Debug Mode'),_('Enable to generate debug messages in `journalctl -f | grep easy-user-switch`'),'debug-mode',extensionSettings,group);
 
         //add empty row to separate Rest Button
         group = new Adw.PreferencesGroup({ title: ' ' });
         page.add(group);
 
         button = new Gtk.Button({
-            label: `Reset Settings to Defaults`,
+            label: _('Reset Settings to Defaults'),
             visible: true
         });
         button.connect('clicked',() => this.resetSettings(extensionSettings, systemSettings));

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -3,9 +3,6 @@ import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-function init() {
-}
-
 export default class EasyUserSwitchPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window){
         const extensionSettings = this.getSettings();

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -27,8 +27,6 @@ export default class EasyUserSwitchPreferences extends ExtensionPreferences {
         // group.set_description('Update Extension Preferences');
         page.add(group);
         this.addToggle('Lock session before switching',"Enable to require password when switching back",'lock-screen-on-switch',extensionSettings,group);
-        let fieldOptions = {'loginctl':'loginctl','chvt':'chvt'};
-        this.addCombo('Switch Method','Default `loginctl`. Using `chvt` requires adding the command to sudoers',fieldOptions,'switch-method',extensionSettings,group);
         this.addToggle('Debug Mode','Enable to generate debug messages in `journalctl -f | grep easy-user-switch`','debug-mode',extensionSettings,group);
 
         //add empty row to separate Rest Button
@@ -77,31 +75,4 @@ export default class EasyUserSwitchPreferences extends ExtensionPreferences {
         return row
     }
 
-    addCombo(rowTitle,rowSubtitle,options,settingName,settings,group){
-        let row = new Adw.ActionRow({ title: rowTitle });
-        row.subtitle = rowSubtitle;
-
-        group.add(row);
-
-        // Create the switch and bind its value to the key
-        let combo = new Gtk.ComboBoxText({
-            valign: Gtk.Align.CENTER,
-            halign: Gtk.Align.END,
-            visible: true
-        });
-        for (let option in options){
-            combo.append(options[option],option);
-        }
-        combo.set_active_id(settings.get_string(settingName));
-
-        combo.connect('changed', () => {
-            settings.set_string(settingName,combo.get_active_id());
-        });
-
-        // Add the switch to the row
-        row.add_suffix(combo);
-        row.activatable_widget = combo;
-
-        return row
-    }
 }

--- a/src/schemas/org.gnome.shell.extensions.easy-user-switch.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.easy-user-switch.gschema.xml
@@ -5,9 +5,6 @@
     <key name="lock-screen-on-switch" type="b">
       <default>false</default>
     </key>
-    <key name="switch-method" type="s">
-      <default>'loginctl'</default>
-    </key>
     <key name="debug-mode" type="b">
       <default>false</default>
     </key>


### PR DESCRIPTION
This series removes historical complexity around session switching.

The extension now relies on `loginctl`, but the tree still carried the older
`chvt` path and the prefs/schema/docs needed to support it. Keeping both paths
made the code harder to follow and maintain for no real benefit.

This series drops the unused legacy path, updates subprocess handling to the
current async GIO style, and cleans up the remaining gettext/metadata/lint
plumbing around it. The intent is to keep behavior the same while making the
supported path clearer and easier to maintain.